### PR TITLE
Experimental modifications to php-vips for extra debugging / attempted fixes

### DIFF
--- a/.github/workflows/test_stability.yml
+++ b/.github/workflows/test_stability.yml
@@ -11,6 +11,7 @@ jobs:
         shutdown_behaviour:
           - 'no_shutdown'
           - 'vips_shutdown'
+          - 'vips_thread_shutdown'
 
     steps:
       - name: Checkout

--- a/html/index.php
+++ b/html/index.php
@@ -25,6 +25,12 @@ if ($shutdown_behaviour === 'vips_shutdown') {
     FFI::shutdown();
 
     Utils::debugLog('FFI::shutdown - done', []);
+} elseif ($shutdown_behaviour === 'vips_thread_shutdown') {
+    Utils::debugLog('Begin FFI::thread_shutdown', []);
+
+    FFI::vips()->vips_thread_shutdown();
+
+    Utils::debugLog('FFI::thread_shutdown - done', []);
 } elseif ($shutdown_behaviour !== 'no_shutdown') {
     throw new \InvalidArgumentException('Bad argument to ?shutdown_behaviour');
 }

--- a/vendor/jcupitt/vips/src/FFI.php
+++ b/vendor/jcupitt/vips/src/FFI.php
@@ -433,7 +433,7 @@ typedef void GParamSpec;
 typedef void GValue;
 
 int vips_init (const char *argv0);
-int vips_shutdown (void);
+void vips_shutdown (void);
 void vips_thread_shutdown (void);
 
 const char *vips_error_buffer (void);

--- a/vendor/jcupitt/vips/src/FFI.php
+++ b/vendor/jcupitt/vips/src/FFI.php
@@ -434,6 +434,7 @@ typedef void GValue;
 
 int vips_init (const char *argv0);
 int vips_shutdown (void);
+void vips_thread_shutdown (void);
 
 const char *vips_error_buffer (void);
 char *vips_error_buffer_copy (void);

--- a/vendor/jcupitt/vips/src/VipsOperation.php
+++ b/vendor/jcupitt/vips/src/VipsOperation.php
@@ -302,8 +302,10 @@ class VipsOperation extends VipsObject
 
         /* Build the operation
          */
+        Utils::debugLog('Calling vips_cache_operation_build', []);
         $pointer = FFI::vips()->
             vips_cache_operation_build($operation->pointer);
+        Utils::debugLog('OK - vips_cache_operation_build returned', []);
         if ($pointer == null) {
             $operation->unrefOutputs();
             throw new Exception();


### PR DESCRIPTION
The source of the segfault is consistently a call to `vips_cache_operation_build()` within the `thumbnail` operation, as can be seen  here: https://github.com/ingenerator/libvips-segfault-repro/actions/runs/3444772326/jobs/5747727585#step:4:548

```
[vips - debug] Begin thumbnail
[vips - debug] thumbnail {"instance":null,"arguments":["\/var\/www\/html\/photo.jpg",600,{"height":1
[vips - debug] init {"library":"libvips.so.42"}
[vips - debug] init {"path":""}
[vips - debug] init {"vips_init":0}
[vips - debug] init {"libvips version":[8,13,3]}
[vips - debug] init ["binding ..."]
[vips - debug] init ["done"]
[vips - debug] thumbnail {"introspect":"thumbnail:\n  filename:\n    flags: 19\n      REQUIRED\n    
[vips - debug] set {"filename":"\/var\/www\/html\/photo.jpg"}
[vips - debug] set {"width":600}
[vips - debug] set {"height":10000000}
[vips - debug] set {"export_profile":"srgb"}
[vips - debug] Calling vips_cache_operation_build
(process:20): GLib-CRITICAL **: 11:48:28.143: g_hash_table_lookup: assertion 'hash_table != NULL' failed
(process:20): GLib-CRITICAL **: 11:48:28.143: g_hash_table_lookup: assertion 'hash_table != NULL' failed
(process:20): GLib-CRITICAL **: 11:48:28.143: g_hash_table_lookup: assertion 'hash_table != NULL' failed
(process:20): GLib-CRITICAL **: 11:48:28.143: g_hash_table_insert_internal: assertion 'hash_table != NULL' failed
(process:20): GLib-CRITICAL **: 11:48:28.143: g_hash_table_lookup: assertion 'hash_table != NULL' failed
[Fri Nov 11 11:48:28.636467 2022] [core:notice] [pid 1] AH00051: child pid 20 exit signal Segmentation fault (11), possible coredump in /etc/apache2
```

Exposing and calling `vips_thread_shutdown()` instead of `vips_shutdown()` avoids the segfault but does not change the memory consumption behaviour.